### PR TITLE
Upgrade kubectl version to 1.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.docker.dockerfile="/Dockerfile"
 
-ENV KUBE_LATEST_VERSION="v1.11.0"
+ENV KUBE_LATEST_VERSION="v1.16.0"
 
 RUN apk add --update ca-certificates curl jq \
  && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \


### PR DESCRIPTION
Kubectl CLI version upgrade to latest of k8s compatible to get advantage of available fixes and specifically to address [kubectl rollout issue](https://github.com/kubernetes/kubernetes/issues/40224) 